### PR TITLE
non-production: set up codecov in this repo

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,3 +6,4 @@ on:
 jobs:
   tests:
     uses: Invoca/ruby-test-matrix-workflow/.github/workflows/ruby-test-matrix.yml@main
+    secrets: inherit

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,5 @@ gem 'pry-byebug'
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.21"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
     byebug (11.1.3)
     coderay (1.1.3)
     diff-lcs (1.5.1)
+    docile (1.4.1)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     method_source (1.1.0)
@@ -61,6 +62,13 @@ GEM
     rubocop-ast (1.31.3)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov-lcov (0.9.0)
+    simplecov_json_formatter (0.1.4)
     strscan (3.1.0)
     thor (1.3.1)
     unicode-display_width (2.5.0)
@@ -76,6 +84,8 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
+  simplecov (~> 0.22)
+  simplecov-lcov (~> 0.8)
 
 BUNDLED WITH
    2.5.5

--- a/gemfiles/appraisal_2_2.gemfile
+++ b/gemfiles/appraisal_2_2.gemfile
@@ -8,5 +8,7 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.21"
 gem "appraisal", "~> 2.2.0"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"
 
 gemspec path: "../"

--- a/gemfiles/appraisal_2_3.gemfile
+++ b/gemfiles/appraisal_2_3.gemfile
@@ -8,5 +8,7 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.21"
 gem "appraisal", "~> 2.3.0"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"
 
 gemspec path: "../"

--- a/gemfiles/appraisal_2_4.gemfile
+++ b/gemfiles/appraisal_2_4.gemfile
@@ -8,5 +8,7 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.21"
 gem "appraisal", "~> 2.4.0"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"
 
 gemspec path: "../"

--- a/gemfiles/appraisal_2_5.gemfile
+++ b/gemfiles/appraisal_2_5.gemfile
@@ -8,5 +8,7 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 gem "rubocop", "~> 1.21"
 gem "appraisal", "~> 2.5.0"
+gem "simplecov", "~> 0.22"
+gem "simplecov-lcov", "~> 0.8"
 
 gemspec path: "../"

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+unless ENV["NO_COVERAGE"] == "true"
+  require "simplecov"
+
+  SimpleCov.start do
+    add_filter "/spec/"
+    track_files "lib/**/*.rb"
+
+    if ENV["GITHUB_ACTIONS"]
+      require "simplecov-lcov"
+
+      SimpleCov::Formatter::LcovFormatter.config do |config|
+        config.report_with_single_file = true
+        config.single_report_path = "coverage/lcov.info"
+      end
+
+      formatter SimpleCov::Formatter::LcovFormatter
+    else
+      formatter SimpleCov::Formatter::HTMLFormatter
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "simplecov_helper"
+
 require 'appraisal'
 require "appraisal/matrix"
 require 'pry'


### PR DESCRIPTION
## Summary
- Add secrets: inherit to .github/workflows/pipeline.yml so the org CODECOV_TOKEN secret reaches the Codecov upload step in the shared ruby-test-matrix workflow
- Add simplecov (~> 0.22) and simplecov-lcov (~> 0.8) as dev dependencies in the Gemfile (this repo's dev-dependency convention), with a new spec/simplecov_helper.rb required first from spec/spec_helper.rb
- On CI (GITHUB_ACTIONS set), coverage is emitted as coverage/lcov.info for the Codecov upload; locally the HTML formatter is used
- Gemfile.lock updated via bundle install (additive only)

## Coverage
Measured locally: Line Coverage: 92.65% (63 / 68), 19 examples, 0 failures.

codecov.yml NOT added: coverage is above the 80% threshold.